### PR TITLE
fix: 最新のredoc-cliはNode.jsバージョン10に対応していないので修正

### DIFF
--- a/redoc-cli/Dockerfile
+++ b/redoc-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:12-alpine
 
 LABEL "com.github.actions.name"="GitHub Action for redoc-cli"
 LABEL "com.github.actions.description"="Use redoc-cli"


### PR DESCRIPTION
### 修正内容
```node:10-alpine```
のイメージで使っているNode.jsのバージョン
```10.24.1```
では、最新のredoc-cliが動きません。

```
TypeError: rules.flatMap is not a function
```
というエラーが出ます。（flatmapは、node 12以上で使える機能）

なので、イメージの参照先をv12に変更しました。

### 備考
ローカル環境でテスト済です